### PR TITLE
Compute a max cardinaility for case where it is unbounded in schema

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
@@ -999,7 +999,7 @@ func ValidateCustomResourceDefinitionOpenAPISchema(schema *apiextensions.JSONSch
 				allErrs = append(allErrs, field.InternalError(fldPath.Child("x-kubernetes-validations"), err))
 			} else {
 				for i, cr := range compResults {
-					expressionCost := getExpressionCost(cr.MaxCost, nodeCostInfo)
+					expressionCost := getExpressionCost(cr, nodeCostInfo)
 					if expressionCost > ExpressionCostLimit {
 						exceedFactor := float64(expressionCost) / float64(ExpressionCostLimit)
 						costErrorMsg := fmt.Sprintf("CEL rule of cost %d exceeded budget of %d by factor of %vx", uint64(expressionCost), ExpressionCostLimit, exceedFactor)
@@ -1071,11 +1071,11 @@ func multiplyWithOverflowGuard(baseCost, cardinality uint64) uint64 {
 	return baseCost * cardinality
 }
 
-func getExpressionCost(baseCost uint64, cardinalityCost costInfo) uint64 {
+func getExpressionCost(cr cel.CompilationResult, cardinalityCost costInfo) uint64 {
 	if cardinalityCost.MaxCardinality != nil {
-		return multiplyWithOverflowGuard(baseCost, *cardinalityCost.MaxCardinality)
+		return multiplyWithOverflowGuard(cr.MaxCost, *cardinalityCost.MaxCardinality)
 	}
-	return baseCost
+	return multiplyWithOverflowGuard(cr.MaxCost, cr.MaxCardinality)
 }
 
 var newlineMatcher = regexp.MustCompile(`[\n\r]+`) // valid newline chars in CEL grammar

--- a/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/schemas.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/third_party/forked/celopenapi/model/schemas.go
@@ -15,6 +15,7 @@
 package model
 
 import (
+	"math"
 	"time"
 
 	"github.com/google/cel-go/checker/decls"
@@ -221,6 +222,19 @@ func WithTypeAndObjectMeta(s *schema.Structural) *schema.Structural {
 	result.Properties = props
 
 	return result
+}
+
+// MaxCardinality returns the maximum number of times data conforming to the schema could possibly exist in
+// an object serialized to JSON. For cases where a schema is contained under map or array schemas of unbounded
+// size, this can be used as an estimate as the worst case number of times data matching the schema could be repeated.
+// Note that this only assumes a single comma between data elements, so if the schema is contained under only maps,
+// this estimates a higher cardinality that would be possible.
+func MaxCardinality(s *schema.Structural) uint64 {
+	sz := estimateMinSizeJSON(s) + 1 // assume at least one comma between elements
+	if sz == 0 {
+		return math.MaxUint64
+	}
+	return uint64(maxRequestSizeBytes / sz)
 }
 
 // estimateMinSizeJSON estimates the minimum size in bytes of the given schema when serialized in JSON.


### PR DESCRIPTION
Add a computed worst case cardinality when computing estimated costs of CEL rules for schema nodes under lists or maps of unbounded size.

Fixes https://gist.github.com/jpbetz/4a8f399b485c6e21c5bc50c5ce55e2ea#file-gistfile1-txt